### PR TITLE
V.2023.09.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,10 @@
-# V.2023.08.17
+# V.2023.09.06
 
-This is the final step of the major refactor plan.
-It focuses on removing duplicate keybindings, revising documentation, and adding two new UI components: TabLine and Winbar.
+This version contains minor improvements and bug fixes.
 
-Removed/changed keybindings and features:
-
-- `[LDR] |`: Use `C-w v` instead
-- `[LDR] -`: Use `C-w s` instead
-- `[LDR] q`: Closes *tab* (i.e., it won't close the Vim if there's only one tab) instead of a window
-            Use `C-w q` to close a window instead
-- `[LDR] hjkl`: Use `C-w hjkl` instead
-- `[LDR] <arrow-key>`: Use `C-w 10 <>-+` to resize window (10 can be any number of pixels) instead
-                     Or use new `[LDR] <>-+` binding to resize window by 1/3 of the current size
-- `[LDR] n`: Toggles `nvim-tree` instead of making a new tab. This is a swap with `[LDR] t`
-- `[LDR] x`: Changed to `[LDR] k` ([k]ill buffer)
-- `[LDR] t`: Creates a new tab instead of toggling `nvim-tree`. This is a swap with `[LDR] n`
-
-- `:TheovimHelp` and was replaced by `:TheovimReadme`
-
-New keybindings and features:
-
-- `[LDR] <>-+`: Resize window by 1/3 of the current size
-- `[LDR] k`: Replaces `[LDR] x` and [k]ills a buffer
-- `[LDR] c e`: Open diagnostics pop-up for the current buffer ([c]ode [e]rror)
-- `[LDR] c p`: Navigate to previous diagnostic ([c]ode [p]rev)
-- `[LDR] c n`: Navigate to next diagnostic ([c]ode [n]ext)
-
-- **`README.md` has been rewritten completely. Please read it!**
-- `listchars` (how Vim renders tab, trailing and leading whitespaces, etc.) has changed. Refer to README.md for more information.
-    - `indent-blankline` plug-in has been replaced with `leadmultispace`
-- **New handmade tabline** replaces `bufferline.nvim`!
-- **New handmade Winbar** is included to help you navigate split windows
-    - LSP information has moved to Winbar to give a buffer-specific LSP information and de-clutter Statusline
-- Highlighting and look of UI components has been changed slightly
-- Completion source for Neovim APIs
+- Add `C-hjkl` keybindings
+    - For example, C-h navigates to the left split window if one exists, otherwise it creates one on the left and navigates to it
+- Add transparency variable. In your `config.lua`, set `vim.g.transparency = true` to enable transparency
+- Add Linux `xdg-open` support for URL opener function
+- Add individual confirmation prompt to `:TrimWhiteSpace` command
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ git clone --depth 1 https://github.com/theopn/theovim.git ~/.config/nvim
     - `[LDR] [`/`]`: Navigate to prev/next buffers
     - `[LDR] k`: **[k]ill buffer**. Delete a buffer. Hit enter to kill the current buffer or type buffer numbers
         ![ldr-k-demo](./assets/ldr-k-demo.gif)
-- Window resizing: Theovim does not offer many window resizing/navigation bindings since Vim already has `C-w` keybindings.
-    Familiarize yourself with `C-hjkl`, `C-w` (for navigating to floating windows), `C-w =`, `C-w |`, etc.
+- Window navigation and resizing
+    Familiarize yourself with `C-w` (for navigating to floating windows), `C-w =`, `C-w |`, etc.
+    - `C-hjkl`: Move to window in each direction (left, below, above, right) or create a split if a window doesn't exist in the direction
     - `[LDR] +`/`-`: Increase/decrease the current window height by one-third
     - `[LDR] >`/`<`: Increase/decrease the current window width by one-third
 - Tab navigation:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     + [Core Keybindings](#core-keybindings)
     + [Core Commands](#core-commands)
     + [Core Options](#core-options)
+    + [Appearance](#appearance)
     + [Spell Check](#spell-check)
     + [Terminal Emulator](#terminal-emulator)
     + [LSP](#lsp)
@@ -187,6 +188,16 @@ Many of these commands are accessible through `[LDR] m` keybinding (reference "M
     vim.opt.scrolloff = 10 --> show at least 10 lines above/below from the current cursor, which is 7 lines by default
     vim.opt.confirm = false --> turn off confirm prompt when quitting with unsaved buffer, which is on by default
     ```
+
+### Appearance
+
+Theovim uses `tokyonight-night` from [tokyonight.nvim](https://github.com/folke/tokyonight.nvim) as a default theme.
+You can toggle transparency in `config.lua`.
+This requires you to configure transparency in your choice of terminal emulator or use Neovide.
+
+```lua
+vim.g.transparency = true
+```
 
 ### Spell Check
 
@@ -384,6 +395,7 @@ StatusLine components:
 ### nvim-tree and Oil
 
 - `[LDR] n`: Toggle `nvim-tree`
+- `:Oil`: Toggle [`oil.nvim`](https://github.com/stevearc/oil.nvim)
 
 ### Miscellaneous Theovim Features
 

--- a/doc/changelog-history.md
+++ b/doc/changelog-history.md
@@ -1,5 +1,42 @@
 # Changelog History
 
+## V.2023.08.17
+
+This is the final step of the major refactor plan.
+It focuses on removing duplicate keybindings, revising documentation, and adding two new UI components: TabLine and Winbar.
+
+Removed/changed keybindings and features:
+
+- `[LDR] |`: Use `C-w v` instead
+- `[LDR] -`: Use `C-w s` instead
+- `[LDR] q`: Closes *tab* (i.e., it won't close the Vim if there's only one tab) instead of a window
+            Use `C-w q` to close a window instead
+- `[LDR] hjkl`: Use `C-w hjkl` instead
+- `[LDR] <arrow-key>`: Use `C-w 10 <>-+` to resize window (10 can be any number of pixels) instead
+                     Or use new `[LDR] <>-+` binding to resize window by 1/3 of the current size
+- `[LDR] n`: Toggles `nvim-tree` instead of making a new tab. This is a swap with `[LDR] t`
+- `[LDR] x`: Changed to `[LDR] k` ([k]ill buffer)
+- `[LDR] t`: Creates a new tab instead of toggling `nvim-tree`. This is a swap with `[LDR] n`
+
+- `:TheovimHelp` and was replaced by `:TheovimReadme`
+
+New keybindings and features:
+
+- `[LDR] <>-+`: Resize window by 1/3 of the current size
+- `[LDR] k`: Replaces `[LDR] x` and [k]ills a buffer
+- `[LDR] c e`: Open diagnostics pop-up for the current buffer ([c]ode [e]rror)
+- `[LDR] c p`: Navigate to previous diagnostic ([c]ode [p]rev)
+- `[LDR] c n`: Navigate to next diagnostic ([c]ode [n]ext)
+
+- **`README.md` has been rewritten completely. Please read it!**
+- `listchars` (how Vim renders tab, trailing and leading whitespaces, etc.) has changed. Refer to README.md for more information.
+    - `indent-blankline` plug-in has been replaced with `leadmultispace`
+- **New handmade tabline** replaces `bufferline.nvim`!
+- **New handmade Winbar** is included to help you navigate split windows
+    - LSP information has moved to Winbar to give a buffer-specific LSP information and de-clutter Statusline
+- Highlighting and look of UI components has been changed slightly
+- Completion source for Neovim APIs
+
 ## Version 2023.07.29
 
 Summary:

--- a/init.lua
+++ b/init.lua
@@ -36,6 +36,7 @@ safe_require("plugins")
 -- Theovim built-in UI elements
 local highlights = safe_require("ui.highlights")
 if highlights then highlights.setup() end
+
 local statusline = safe_require("ui.statusline")
 if statusline then statusline.setup() end
 local tabline = safe_require("ui.tabline")
@@ -44,6 +45,9 @@ local winbar = safe_require("ui.winbar")
 if winbar then winbar.setup() end
 local dashboard = safe_require("ui.dashboard")
 if dashboard then dashboard.setup() end
+
+local notepad = safe_require("ui.notepad")
+if notepad then notepad.setup() end
 
 -- LSP configurations
 safe_require("lsp.lsp")

--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,9 @@ local function safe_require(module)
   return nil
 end
 
+-- User configuration
+safe_require("config")
+
 -- Core config modules
 safe_require("core")
 safe_require("plugins")
@@ -59,6 +62,3 @@ safe_require("config.treesitter")
 
 -- Other Theovim features
 safe_require("misc")
-
--- User configuration
-safe_require("config")

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -13,6 +13,9 @@
 vim.g.vimtex_view_method = "skim"
 --vim.g.vimtex_view_method = "zathura"
 
+-- Toggle transparency -- requires you to have a transparent terminal or Neovide
+vim.g.transparency = false
+
 -- Theo's Neovide settings
 if vim.g.neovide then
   local padding = 10
@@ -23,4 +26,6 @@ if vim.g.neovide then
 
   vim.g.neovide_hide_mouse_when_typing = true
   vim.g.neovide_cursor_vfx_mode = "railgun"
+
+  vim.g.neovide_transparency = 0.69
 end

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -195,6 +195,30 @@ local function url_handler()
   end
 end
 
+--[[ move_or_create_win()
+-- Move to a window (one of hjkl) or create a split if a window does not exist in the direction
+-- Vimscript translation of:
+-- https://www.reddit.com/r/vim/comments/166a3ij/comment/jyivcnl/?utm_source=share&utm_medium=web2x&context=3
+-- Usage: vim.keymap("n", "<C-h>", function() move_or_create_win("h") end, {})
+--
+-- @arg key: One of h, j, k, l, a direction to move or create a split
+--]]
+local function move_or_create_win(key)
+  local fn = vim.fn
+  local curr_win = fn.winnr()
+  vim.cmd("wincmd " .. key)        --> attempt to move
+
+  if (curr_win == fn.winnr()) then --> didn't move, so create a split
+    if key == "h" or key == "l" then
+      vim.cmd("wincmd v")
+    else
+      vim.cmd("wincmd s")
+    end
+
+    vim.cmd("wincmd " .. key)
+  end
+end
+
 -- {{{ Keybinding table
 local key_opt = {
   -- Convenience --
@@ -270,6 +294,10 @@ local key_opt = {
   },
 
   -- Window --
+  { "n", "<C-h>", function() move_or_create_win("h") end, "[h]: Move to window on the left or create a split", },
+  { "n", "<C-j>", function() move_or_create_win("j") end, "[j]: Move to window below or create a vertical split", },
+  { "n", "<C-k>", function() move_or_create_win("k") end, "[k]: Move to window above or create a vertical split", },
+  { "n", "<C-l>", function() move_or_create_win("l") end, "[l]: Move to window on the right or create a split", },
   {
     'n',
     "<leader>+",

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -180,9 +180,10 @@ local function url_handler()
   if url ~= nil then
     -- If URL is found, determine the open command to use
     local cmd = nil
-    if vim.fn.has("mac") then
+    local sysname = vim.loop.os_uname().sysname
+    if sysname == "Darwin" then --> or use vim.fn.has("mac" or "linux", etc.)
       cmd = "open"
-    elseif vim.fn.has("linux") then
+    elseif sysname == "Linux" then
       cmd = "xdg-open"
     end
     -- Open the URL using exec

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -172,12 +172,23 @@ vim.g.mapleader = " "                                            --> Space as th
 
 --[[ url_handler()
 -- Find the URL in the current line and open it in a browser if possible
+-- @requires macOS open command or Linux xdg-open
 --]]
 local function url_handler()
-  -- <something>://<something that aren't >,;)>
-  local url = string.match(vim.fn.getline("."), "[a-z]*://[^ >,;)]*")
+  -- <something>://<something that aren't >,;")>
+  local url = string.match(vim.fn.getline("."), "[a-z]*://[^ >,;)\"']*")
   if url ~= nil then
-    vim.cmd("silent exec '!open " .. url .. "'")
+    -- If URL is found, determine the open command to use
+    local cmd = nil
+    if vim.fn.has("mac") then
+      cmd = "open"
+    elseif vim.fn.has("linux") then
+      cmd = "xdg-open"
+    end
+    -- Open the URL using exec
+    if cmd then
+      vim.cmd('exec "!' .. cmd .. " '" .. url .. "'" .. '"') --> exec "!open 'foo://bar baz'"
+    end
   else
     vim.notify("No URI found in the current line")
   end

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -157,6 +157,7 @@ vim.api.nvim_create_autocmd("TermClose", {
   callback = function()
     if vim.v.event.status == 0 then
       vim.api.nvim_buf_delete(0, {})
+      vim.notify_once("Previous terminal job was successful!")
     else
       vim.notify_once("Error code detected in the current terminal job!")
     end

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -186,17 +186,17 @@ end
 -- {{{ Keybinding table
 local key_opt = {
   -- Convenience --
-  { 'i', "jk",        "<ESC>",              "[j]o[k]er: Better ESC" },
-  { 'n', "<leader>a", "gg<S-v>G",           "[a]ll: select all" },
-  { 'n', "gx",        url_handler,          "Open URL under the cursor using shell open command" },
+  { 'i', "jk",        "<ESC>",        "[j]o[k]er: Better ESC" },
+  { 'n', "<leader>a", "gg<S-v>G",     "[a]ll: select all" },
+  { 'n', "gx",        url_handler,    "Open URL under the cursor using shell open command" },
 
   -- Search --
-  { 'n', "n",         "nzz",                "Highlight next search and center the screen" },
-  { 'n', "N",         "Nzz",                "Highlight prev search and center the screen" },
-  { 'n', "<leader>/", "<CMD>let @/=''<CR>", "[/]: clear search" }, --> @/ is the macro for the last search
+  { 'n', "n",         "nzz",          "Highlight next search and center the screen" },
+  { 'n', "N",         "Nzz",          "Highlight prev search and center the screen" },
+  { 'n', "<leader>/", "<CMD>noh<CR>", "[/]: clear search" }, --> @/ is the macro for the last search
 
   -- Copy and paste --
-  { 'x', "<leader>y", '"+y',                "[y]ank: yank to the system clipboard (+)" },
+  { 'x', "<leader>y", '"+y',          "[y]ank: yank to the system clipboard (+)" },
   {
     'n',
     "<leader>p",

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -198,14 +198,14 @@ end
 -- {{{ Keybinding table
 local key_opt = {
   -- Convenience --
-  { 'i', "jk",        "<ESC>",        "[j]o[k]er: Better ESC" },
+  { 'i', "jk",        "<ESC>",        "Better ESC" },
   { 'n', "<leader>a", "gg<S-v>G",     "[a]ll: select all" },
   { 'n', "gx",        url_handler,    "Open URL under the cursor using shell open command" },
 
   -- Search --
   { 'n', "n",         "nzz",          "Highlight next search and center the screen" },
   { 'n', "N",         "Nzz",          "Highlight prev search and center the screen" },
-  { 'n', "<leader>/", "<CMD>noh<CR>", "[/]: clear search" }, --> @/ is the macro for the last search
+  { 'n', "<leader>/", "<CMD>noh<CR>", "[/]: clear search" },
 
   -- Copy and paste --
   { 'x', "<leader>y", '"+y',          "[y]ank: yank to the system clipboard (+)" },
@@ -313,11 +313,11 @@ local key_opt = {
     "<CMD>tabclose<CR>",
     "[q]uit: close current tab",
   },
-  { 'n', "<leader>1", "1gt", }, --> Go to 1st tab
-  { 'n', "<leader>2", "2gt", },
-  { 'n', "<leader>3", "3gt", },
-  { 'n', "<leader>4", "4gt", },
-  { 'n', "<leader>5", "5gt", },
+  { 'n', "<leader>1", "1gt", "Go to tab 1" },
+  { 'n', "<leader>2", "2gt", "Go to tab 2" },
+  { 'n', "<leader>3", "3gt", "Go to tab 3" },
+  { 'n', "<leader>4", "4gt", "Go to tab 4" },
+  { 'n', "<leader>5", "5gt", "Go to tab 5" },
 
   -- LSP --
   {

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -61,9 +61,16 @@ do
   for _, v in ipairs(edit_opt) do
     opt[v[1]] = v[2]
   end
-  -- Trimming extra whitespaces --
-  -- \s: white space char, \+ :one or more, $: end of the line, e: suppresses warning, no need for <CR> for usercmd
-  vim.api.nvim_create_user_command("TrimWhitespace", ":let save=@/<BAR>:%s/\\s\\+$//e<BAR>:let @/=save<BAR>",
+  --[[ trim_whitespace()
+  -- Vimscript-based function to trim trailing whitespaces
+  -- \s: white space char, \+ :one or more, $: end of the line, e: suppresses warning when no match found, c: confirm
+  --]]
+  local function trim_whitespace()
+    local win_save = vim.fn.winsaveview()
+    vim.cmd("keeppatterns %s/\\s\\+$//ec")
+    vim.fn.winrestview(win_save)
+  end
+  vim.api.nvim_create_user_command("TrimWhitespace", trim_whitespace,
     { nargs = 0 })
   -- Show the changes made since the last write
   vim.api.nvim_create_user_command("ShowChanges", ":w !diff % -",

--- a/lua/misc.lua
+++ b/lua/misc.lua
@@ -42,10 +42,6 @@ do
   vim.api.nvim_create_user_command("TheovimChangelogHistory", changelog_hist_func, { nargs = 0 })
 end
 
-do
-  vim.api.nvim_create_user_command("Notepad", util.launch_notepad, { nargs = 0 })
-end
-
 -- {{{ Git menu
 local git_options = {
   ["0. Diff Current Buffer"] = "Git diffthis",

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -24,13 +24,14 @@ local plugins = {
   {
     "folke/tokyonight.nvim", --> colorscheme
     config = function()
-      vim.cmd([[
-      try
-        colo tokyonight-night
-      catch
-        colo slate
-      endtry
-      ]])
+      require("tokyonight").setup({
+        transparent = vim.g.transparency or false,
+        styles = {
+          sidebars = vim.g.transparency and "transparent" or "dark",
+          floats = vim.g.transparency and "transparent" or "dark",
+        },
+      })
+      vim.cmd("colo tokyonight-night")
     end,
   },
   {

--- a/lua/ui/notepad.lua
+++ b/lua/ui/notepad.lua
@@ -33,13 +33,15 @@ function M.toggle_notepad()
       vim.api.nvim_buf_set_option(M.notepad_buf, "bufhidden", "hide")
       vim.api.nvim_buf_set_option(M.notepad_buf, "filetype", "markdown")
       vim.api.nvim_buf_set_lines(M.notepad_buf, 0, 1, false,
-        { "# Theovim Notepad",
+        { "# Warning",
           "",
           "> Notepad clears when the current Neovim session closes",
         })
     end
     -- Create a window
     M.notepad_win = vim.api.nvim_open_win(M.notepad_buf, true, {
+      title = "Theovim Notepad",
+      title_pos = "center",
       border = "rounded",
       relative = "editor",
       style = "minimal",

--- a/lua/ui/notepad.lua
+++ b/lua/ui/notepad.lua
@@ -1,0 +1,70 @@
+--[[ notepad.lua
+-- $ figlet -f nancyj theovim
+--   dP   dP                                  oo
+--   88   88
+-- d8888P 88d888b. .d8888b. .d8888b. dP   .dP dP 88d8b.d8b.
+--   88   88'  `88 88ooood8 88'  `88 88   d8' 88 88'`88'`88
+--   88   88    88 88.  ... 88.  .88 88 .88'  88 88  88  88
+--   dP   dP    dP `88888P' `88888P' 8888P'   dP dP  dP  dP
+--
+-- This module provides a framework to launch a small,
+-- transparent floating window with a scartch buffer that persists until Neovim closes
+--]]
+M = {}
+
+-- Because these variables belong to module,
+-- it is recommended that require("ui.notepad") call only happens once in the entire config
+-- Otherwise, you will have multiple scratch buffer with multiple notepad status
+M.notepad_loaded = false
+M.notepad_buf, M.notepad_win = nil, nil
+
+--[[ launch_notepad()
+-- Checkes if notepad window is active first
+-- then checkes if notepad buffer has been initialized. If so, reuse the buffer, else, create a new scratch buffer
+-- If window is not active, display a small floating window with the scratch buffer
+--
+-- @requires M.notepad_loaded, M.notepad_buf, M.notepad_win variables in util (this) module
+--]]
+function M.toggle_notepad()
+  if not M.notepad_loaded or not vim.api.nvim_win_is_valid(M.notepad_win) then
+    if not M.notepad_buf or not vim.api.nvim_buf_is_valid(M.notepad_buf) then
+      -- Create a buffer if it none existed
+      M.notepad_buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_option(M.notepad_buf, "bufhidden", "hide")
+      vim.api.nvim_buf_set_option(M.notepad_buf, "filetype", "markdown")
+      vim.api.nvim_buf_set_lines(M.notepad_buf, 0, 1, false,
+        { "# Theovim Notepad",
+          "",
+          "> Notepad clears when the current Neovim session closes",
+        })
+    end
+    -- Create a window
+    M.notepad_win = vim.api.nvim_open_win(M.notepad_buf, true, {
+      border = "rounded",
+      relative = "editor",
+      style = "minimal",
+      height = math.ceil(vim.o.lines * 0.5),
+      width = math.ceil(vim.o.columns * 0.5),
+      row = 1,                                                 --> Top of the window
+      col = math.ceil(vim.o.columns * 0.5),                    --> Far right; should add up to 1 with win_width
+    })
+    vim.api.nvim_win_set_option(M.notepad_win, "winblend", 30) --> Semi transparent buffer
+
+    -- Keymaps
+    local keymaps_opts = { silent = true, buffer = M.notepad_buf }
+    vim.keymap.set('n', "<ESC>", function() M.toggle_notepad() end, keymaps_opts)
+    vim.keymap.set('n', "q", function() M.toggle_notepad() end, keymaps_opts)
+  else
+    vim.api.nvim_win_hide(M.notepad_win)
+  end
+  M.notepad_loaded = not M.notepad_loaded
+end
+
+--[[ setup()
+-- Creates an autocommand to launch the notepad
+--]]
+M.setup = function()
+  vim.api.nvim_create_user_command("Notepad", M.toggle_notepad, { nargs = 0 })
+end
+
+return M

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -207,46 +207,4 @@ M.spawn_floting_doc_win = function(file_path)
   return float_win
 end
 
---[[ launch_notepad()
--- Launch a small, transparent floating window with a scartch buffer that persists until Neovim closes
---
--- @requires M.notepad_loaded, M.notepad_buf, M.notepad_win variables in util (this) module
---]]
-M.notepad_loaded = false
-M.notepad_buf, M.notepad_win = nil, nil
-function M.launch_notepad()
-  if not M.notepad_loaded or not vim.api.nvim_win_is_valid(M.notepad_win) then
-    if not M.notepad_buf or not vim.api.nvim_buf_is_valid(M.notepad_buf) then
-      -- Create a buffer if it none existed
-      M.notepad_buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_option(M.notepad_buf, "bufhidden", "hide")
-      vim.api.nvim_buf_set_option(M.notepad_buf, "filetype", "markdown")
-      vim.api.nvim_buf_set_lines(M.notepad_buf, 0, 1, false,
-        { "# Theovim Notepad",
-          "",
-          "> Notepad clears when the current Neovim session closes",
-        })
-    end
-    -- Create a window
-    M.notepad_win = vim.api.nvim_open_win(M.notepad_buf, true, {
-      border = "rounded",
-      relative = "editor",
-      style = "minimal",
-      height = math.ceil(vim.o.lines * 0.5),
-      width = math.ceil(vim.o.columns * 0.5),
-      row = 1,                                                 --> Top of the window
-      col = math.ceil(vim.o.columns * 0.5),                    --> Far right; should add up to 1 with win_width
-    })
-    vim.api.nvim_win_set_option(M.notepad_win, "winblend", 30) --> Semi transparent buffer
-
-    -- Keymaps
-    local keymaps_opts = { silent = true, buffer = M.notepad_buf }
-    vim.keymap.set('n', "<ESC>", function() M.launch_notepad() end, keymaps_opts)
-    vim.keymap.set('n', "q", function() M.launch_notepad() end, keymaps_opts)
-  else
-    vim.api.nvim_win_hide(M.notepad_win)
-  end
-  M.notepad_loaded = not M.notepad_loaded
-end
-
 return M


### PR DESCRIPTION
This version contains minor improvements and bug fixes.

- Add `C-hjkl` keybindings
    - For example, C-h navigates to the left split window if one exists, otherwise it creates one on the left and navigates to it
- Add transparency variable. In your `config.lua`, set `vim.g.transparency = true` to enable transparency
- Add Linux `xdg-open` support for URL opener function
- Add individual confirmation prompt to `:TrimWhiteSpace` command

